### PR TITLE
Add support for pod-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,25 @@ It works by
 5. Deletes the pod.
 
 Requires the image contain `tail` and `tar`.
+
+You can provide a file with `--pod-file pod.yaml` to specify additional options for the pod or add a sidecar, as in
+```
+spec:
+  containers:
+  - name: selenium
+    image: selenium/standalone-chrome
+    ports:
+    - name: selenium
+      containerPort: 4444
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 4444
+    volumeMounts:
+    - mountPath: /dev/shm
+      name: dshm
+  volumes:
+  - name: dshm
+    emptyDir:
+    medium: Memory
+```

--- a/kubectl-ran.go
+++ b/kubectl-ran.go
@@ -51,6 +51,7 @@ func NewCmdRan(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&o.PodFile, "pod-file", "f", "", "YAML file containing a pod definition; container named '"+ran.ContainerName+"' will be overwritten with specified image and used for command execution")
 	cmd.Flags().StringArrayVarP(&o.EnvVars, "env", "e", []string{}, "environment variables for the container")
 	cmd.Flags().StringArrayVarP(&o.Volumes, "volume", "v", []string{}, "volumes to sync")
 	cmd.Flags().StringVar(&o.Cpu, "cpu", "", "cpu requirements for the container")

--- a/pkg/ran/exec.go
+++ b/pkg/ran/exec.go
@@ -23,7 +23,8 @@ func (e executor) execute(pod, namespace string, command []string, opts remoteco
 		Resource("pods").
 		Name(pod).
 		Namespace(namespace).
-		SubResource("exec")
+		SubResource("exec").
+		Param("container", ContainerName)
 
 	if opts.Stdin != nil {
 		req = req.Param("stdin", "true")


### PR DESCRIPTION
Adds the `--pod-file,-f` option to specify a pod file so you can customize the pod. This is deserialized directly into a Pod resource definition, so you can add things like labels, custom name, volumes, security constraints, etc.

Overrides:
- if a pod name is not provided `generateName` will be set
- if a container named `worker` is included it will be used for command execution; the image is always overridden by the command arg
- if command and args are empty, they'll be set to `tail -f /dev/null`
- command-line env vars will be appended to `env` on the `worker` container
- command-line resource requests override requests/limits on the container