### PR TITLE
Auto-publish releases to homebrew-puppet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,4 @@ jobs:
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,3 +28,11 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+brews:
+  - tap:
+      owner: puppetlabs
+      name: homebrew-puppet
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/puppetlabs/kubectl-ran
+    description: A Kubernetes addon for running an ephemeral container with a "mounted" volume.
+    license: "Apache 2.0"


### PR DESCRIPTION
Auto-publishes releases to homebrew-puppet using https://goreleaser.com/customization/homebrew/. Includes configuration for MacOS ARM and Linux.